### PR TITLE
Update Docker instructions and env vars in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,18 @@ python main.py 123456:ABC-DEF your_api_key_1,your_api_key_2 --admin-uid 12345678
 
 ```bash
 # 构建 Docker 镜像
-docker build -t gemini-telegram-bot .
+docker build -t gemini_tg_bot .
 
 # 运行容器
 docker run -d --name gemini-bot \
-  -e TG_TOKEN="<你的TG_BOT_TOKEN>" \
-  -e GEMINI_KEY="<你的GEMINI_API_KEY>" \
-  -e ADMIN_UID="<你的管理员UID>" \
-  gemini-telegram-bot
+  -e TELEGRAM_BOT_API_KEY="<你的TG_BOT_TOKEN>" \
+  -e GEMINI_API_KEYS="<你的GEMINI_API_KEY>" \
+  -e ADMIN_UIDS="<你的管理员UID>" \
+  gemini_tg_bot
 ```
 
 **注意**: 在 Docker 中，环境变量的值应该用引号括起来。多个 API 密钥请用逗号分隔，多个管理员 UID 请用空格分隔。
+
+
 
 ```

--- a/README_en.md
+++ b/README_en.md
@@ -94,14 +94,15 @@ python main.py 123456:ABC-DEF your_api_key_1,your_api_key_2 --admin-uid 12345678
 
 ```bash
 # Build the Docker image
-docker build -t gemini-telegram-bot .
+docker build -t gemini_tg_bot .
 
 # Run the container
 docker run -d --name gemini-bot \
-  -e TG_TOKEN="<YOUR_TG_BOT_TOKEN>" \
-  -e GEMINI_KEY="<YOUR_GEMINI_API_KEY>" \
-  -e ADMIN_UID="<YOUR_ADMIN_UID>" \
-  gemini-telegram-bot
+  -e TELEGRAM_BOT_API_KEY="<YOUR_TG_BOT_TOKEN>" \
+  -e GEMINI_API_KEYS="<YOUR_GEMINI_API_KEY>" \
+  -e ADMIN_UIDS="<YOUR_ADMIN_UID>" \
+  gemini_tg_bot
 ```
 
 **Note**: When using Docker, enclose the environment variable values in quotes. For multiple API keys, separate them with commas. For multiple admin UIDs, separate them with spaces.
+


### PR DESCRIPTION
Changed Docker image name from 'gemini-telegram-bot' to 'gemini_tg_bot' and updated environment variable names for clarity in both README.md and README_en.md. This improves consistency and better reflects the actual variable usage in Docker deployment.